### PR TITLE
Change names of dlls copied to SMath wrapper: use underscore instead of dot

### DIFF
--- a/Web/coolprop/wrappers/SMath/index.rst
+++ b/Web/coolprop/wrappers/SMath/index.rst
@@ -42,7 +42,7 @@ Native Wrapper
 
 4. Make sure the mode is set to Release (not Debug).  Build the project, the generated and copied files will be in ``build/wrappers/SMath/coolprop_wrapper/bin/Release``.
 
-5. From the :sfdownloads:`download page <shared_library>`, download the 64-bit DLL ``CoolProp.dll`` file from ``Windows/64bit`` folder and rename to ``CoolProp.x64.dll`` and place with the files in ``build/wrappers/SMath/coolprop_wrapper/bin/Release``.  Download the 32-bit ``__stdcall`` DLL ``CoolProp.dll`` from ``Windows/32bit__stdcall_calling_convention`` and rename to ``CoolProp.x86.dll`` and place with the files in ``build/wrappers/SMath/coolprop_wrapper/bin/Release``.
+5. From the :sfdownloads:`download page <shared_library>`, download the 64-bit DLL ``CoolProp.dll`` file from ``Windows/64bit`` folder and rename to ``CoolProp_x64.dll`` and place with the files in ``build/wrappers/SMath/coolprop_wrapper/bin/Release``.  Download the 32-bit ``__stdcall`` DLL ``CoolProp.dll`` from ``Windows/32bit__stdcall_calling_convention`` and rename to ``CoolProp_x86.dll`` and place with the files in ``build/wrappers/SMath/coolprop_wrapper/bin/Release``.
 
 6. Run the ``build_zip.bat`` file that is in the ``build/wrappers/SMath`` folder.  It will create a zip file with the needed files. 
 

--- a/dev/buildbot/master/master.cfg
+++ b/dev/buildbot/master/master.cfg
@@ -787,7 +787,7 @@ def smath_builder():
                                  haltOnFailure = True))
     factory.addStep(ShellCommand(command=["cmake", "--build", ".", "--target", "install", "--config", "Release"], workdir = working_folder+'/32bitDLL', haltOnFailure = True))
     # Copy the created DLL
-    factory.addStep(ShellCommand(command=' '.join(["copy", "/Y", "install_root\\shared_library\\Windows\\32bit__stdcall\\CoolProp.dll", "wrappers\\SMath\\coolprop_wrapper\\bin\\Release\\CoolProp.x86.dll"]), workdir = 'build', haltOnFailure = True))
+    factory.addStep(ShellCommand(command=' '.join(["copy", "/Y", "install_root\\shared_library\\Windows\\32bit__stdcall\\CoolProp.dll", "wrappers\\SMath\\coolprop_wrapper\\bin\\Release\\CoolProp_x86.dll"]), workdir = 'build', haltOnFailure = True))
 
     # ***************
     # Make 64-bit DLL
@@ -796,7 +796,7 @@ def smath_builder():
                                  workdir= working_folder+'/64bitDLL',
                                  haltOnFailure = True))
     factory.addStep(ShellCommand(command=["cmake", "--build", ".", "--target", "install", "--config", "Release"], workdir = working_folder+'/64bitDLL', haltOnFailure = True))
-    factory.addStep(ShellCommand(command=' '.join(["copy", "/Y", "install_root\\shared_library\\Windows\\64bit\\CoolProp.dll", "wrappers\\SMath\\coolprop_wrapper\\bin\\Release\\CoolProp.x64.dll"]), workdir = 'build', haltOnFailure = True))
+    factory.addStep(ShellCommand(command=' '.join(["copy", "/Y", "install_root\\shared_library\\Windows\\64bit\\CoolProp.dll", "wrappers\\SMath\\coolprop_wrapper\\bin\\Release\\CoolProp_x64.dll"]), workdir = 'build', haltOnFailure = True))
 
     # Copy other files to a temporary directory
     factory.addStep(ShellCommand(command=["build_zip"], workdir = 'build\\wrappers\\SMath\\coolprop_wrapper', haltOnFailure = True))

--- a/wrappers/SMath/coolprop_wrapper/Functions/CoolProp_HAProps.cs
+++ b/wrappers/SMath/coolprop_wrapper/Functions/CoolProp_HAProps.cs
@@ -7,7 +7,7 @@ namespace coolprop_wrapper.Functions
   {
     // double HAPropsSI(const char *Output, const char *Name1, double Prop1, const char *Name2, double Prop2, const char *Name3, double Prop3);
     [DllImport(
-      "CoolProp.x86.dll", EntryPoint = "HAPropsSI",
+      "CoolProp_x86", EntryPoint = "HAPropsSI",
       CharSet = CharSet.Ansi)]
     internal static extern double CoolPropDLLfunc_x86(
       string Output,
@@ -18,7 +18,7 @@ namespace coolprop_wrapper.Functions
       string Name3,
       double Prop3);
     [DllImport(
-      "CoolProp.x64.dll", EntryPoint = "HAPropsSI",
+      "CoolProp_x64", EntryPoint = "HAPropsSI",
       CharSet = CharSet.Ansi)]
     internal static extern double CoolPropDLLfunc_x64(
       string Output,

--- a/wrappers/SMath/coolprop_wrapper/Functions/CoolProp_Phase.cs
+++ b/wrappers/SMath/coolprop_wrapper/Functions/CoolProp_Phase.cs
@@ -7,7 +7,7 @@ namespace coolprop_wrapper.Functions
   {
     // long PhaseSI(const char *Name1, double Prop1, const char *Name2, double Prop2, const char *Ref, char *phase, int n);
     [DllImport(
-      "CoolProp.x86.dll", EntryPoint="PhaseSI",
+      "CoolProp_x86", EntryPoint="PhaseSI",
       CharSet = CharSet.Ansi)]
     internal static extern long CoolPropDLLfunc_x86(
       string Name1,
@@ -18,7 +18,7 @@ namespace coolprop_wrapper.Functions
       System.Text.StringBuilder phase,
       int n);
     [DllImport(
-      "CoolProp.x64.dll", EntryPoint = "PhaseSI",
+      "CoolProp_x64", EntryPoint = "PhaseSI",
       CharSet = CharSet.Ansi)]
     internal static extern long CoolPropDLLfunc_x64(
       string Name1,

--- a/wrappers/SMath/coolprop_wrapper/Functions/CoolProp_Props.cs
+++ b/wrappers/SMath/coolprop_wrapper/Functions/CoolProp_Props.cs
@@ -7,7 +7,7 @@ namespace coolprop_wrapper.Functions
   {
     //  double PropsSI(const char *Output, const char *Name1, double Prop1, const char *Name2, double Prop2, const char *Ref);
     [DllImport(
-      "CoolProp.x86.dll", EntryPoint = "PropsSI",
+      "CoolProp_x86", EntryPoint = "PropsSI",
       CharSet = CharSet.Ansi)]
     internal static extern double CoolPropDLLfunc_x86(
       string Output,
@@ -17,7 +17,7 @@ namespace coolprop_wrapper.Functions
       double Prop2,
       string FluidName);
     [DllImport(
-      "CoolProp.x64.dll", EntryPoint = "PropsSI",
+      "CoolProp_x64", EntryPoint = "PropsSI",
       CharSet = CharSet.Ansi)]
     internal static extern double CoolPropDLLfunc_x64(
       string Output,

--- a/wrappers/SMath/coolprop_wrapper/Functions/CoolProp_Props1.cs
+++ b/wrappers/SMath/coolprop_wrapper/Functions/CoolProp_Props1.cs
@@ -7,13 +7,13 @@ namespace coolprop_wrapper.Functions
   {
     // double Props1SI(const char *FluidName, const char* Output);
     [DllImport(
-      "CoolProp.x86.dll", EntryPoint = "Props1SI",
+      "CoolProp_x86", EntryPoint = "Props1SI",
       CharSet = CharSet.Ansi)]
     internal static extern double CoolPropDLLfunc_x86(
       string FluidName,
       string Output);
     [DllImport(
-      "CoolProp.x64.dll", EntryPoint = "Props1SI",
+      "CoolProp_x64", EntryPoint = "Props1SI",
       CharSet = CharSet.Ansi)]
     internal static extern double CoolPropDLLfunc_x64(
       string FluidName,

--- a/wrappers/SMath/coolprop_wrapper/Functions/CoolProp_get_fluid_param_string.cs
+++ b/wrappers/SMath/coolprop_wrapper/Functions/CoolProp_get_fluid_param_string.cs
@@ -7,7 +7,7 @@ namespace coolprop_wrapper.Functions
   {
     // long get_fluid_param_string(const char *fluid, const char *param, char *Output, int n);
     [DllImport(
-      "CoolProp.x86.dll", EntryPoint = "get_fluid_param_string",
+      "CoolProp_x86", EntryPoint = "get_fluid_param_string",
       CharSet = CharSet.Ansi)]
     internal static extern long CoolPropDLLfunc_x86(
       string fluid,
@@ -15,7 +15,7 @@ namespace coolprop_wrapper.Functions
       System.Text.StringBuilder Output,
       int n);
     [DllImport(
-      "CoolProp.x64.dll", EntryPoint = "get_fluid_param_string",
+      "CoolProp_x64", EntryPoint = "get_fluid_param_string",
       CharSet = CharSet.Ansi)]
     internal static extern long CoolPropDLLfunc_x64(
       string fluid,

--- a/wrappers/SMath/coolprop_wrapper/Functions/CoolProp_get_global_param_string.cs
+++ b/wrappers/SMath/coolprop_wrapper/Functions/CoolProp_get_global_param_string.cs
@@ -7,14 +7,14 @@ namespace coolprop_wrapper.Functions
   {
     // long get_global_param_string(const char *param, char *Output, int n);
     [DllImport(
-      "CoolProp.x86.dll", EntryPoint = "get_global_param_string",
+      "CoolProp_x86", EntryPoint = "get_global_param_string",
       CharSet = CharSet.Ansi)]
     internal static extern long CoolPropDLLfunc_x86(
       string param,
       System.Text.StringBuilder Output,
       int n);
     [DllImport(
-      "CoolProp.x64.dll", EntryPoint = "get_global_param_string",
+      "CoolProp_x64", EntryPoint = "get_global_param_string",
       CharSet = CharSet.Ansi)]
     internal static extern long CoolPropDLLfunc_x64(
       string param,

--- a/wrappers/SMath/coolprop_wrapper/Functions/CoolProp_get_param_index.cs
+++ b/wrappers/SMath/coolprop_wrapper/Functions/CoolProp_get_param_index.cs
@@ -7,12 +7,12 @@ namespace coolprop_wrapper.Functions
   {
     // long get_param_index(const char *param);
     [DllImport(
-      "CoolProp.x86.dll", EntryPoint = "get_param_index",
+      "CoolProp_x86", EntryPoint = "get_param_index",
       CharSet = CharSet.Ansi)]
     internal static extern long CoolPropDLLfunc_x86(
       string param);
     [DllImport(
-      "CoolProp.x64.dll", EntryPoint = "get_param_index",
+      "CoolProp_x64", EntryPoint = "get_param_index",
       CharSet = CharSet.Ansi)]
     internal static extern long CoolPropDLLfunc_x64(
       string param);

--- a/wrappers/SMath/coolprop_wrapper/Functions/CoolProp_get_parameter_information_string.cs
+++ b/wrappers/SMath/coolprop_wrapper/Functions/CoolProp_get_parameter_information_string.cs
@@ -7,14 +7,14 @@ namespace coolprop_wrapper.Functions
   {
     // long get_parameter_information_string(const char *key, char *Output, int n);
     [DllImport(
-      "CoolProp.x86.dll", EntryPoint = "get_parameter_information_string",
+      "CoolProp_x86", EntryPoint = "get_parameter_information_string",
       CharSet = CharSet.Ansi)]
     internal static extern long CoolPropDLLfunc_x86(
       string key,
       System.Text.StringBuilder Output,
       int n);
     [DllImport(
-      "CoolProp.x64.dll", EntryPoint = "get_parameter_information_string",
+      "CoolProp_x64", EntryPoint = "get_parameter_information_string",
       CharSet = CharSet.Ansi)]
     internal static extern long CoolPropDLLfunc_x64(
       string key,

--- a/wrappers/SMath/coolprop_wrapper/Functions/CoolProp_saturation_ancillary.cs
+++ b/wrappers/SMath/coolprop_wrapper/Functions/CoolProp_saturation_ancillary.cs
@@ -7,7 +7,7 @@ namespace coolprop_wrapper.Functions
   {
     // double saturation_ancillary(const char *fluid_name, const char *output, int Q, const char *input, double value);
     [DllImport(
-      "CoolProp.x86.dll", EntryPoint = "saturation_ancillary",
+      "CoolProp_x86", EntryPoint = "saturation_ancillary",
       CharSet = CharSet.Ansi)]
     internal static extern double CoolPropDLLfunc_x86(
       string fluid_name,
@@ -16,7 +16,7 @@ namespace coolprop_wrapper.Functions
       string input,
       double value);
     [DllImport(
-      "CoolProp.x64.dll", EntryPoint = "saturation_ancillary",
+      "CoolProp_x64", EntryPoint = "saturation_ancillary",
       CharSet = CharSet.Ansi)]
     internal static extern double CoolPropDLLfunc_x64(
       string fluid_name,

--- a/wrappers/SMath/coolprop_wrapper/Functions/CoolProp_set_reference_stateD.cs
+++ b/wrappers/SMath/coolprop_wrapper/Functions/CoolProp_set_reference_stateD.cs
@@ -7,7 +7,7 @@ namespace coolprop_wrapper.Functions
   {
     // int set_reference_stateD(const char *Ref, double T, double rho, double h0, double s0);
     [DllImport(
-      "CoolProp.x86.dll", EntryPoint = "set_reference_stateD",
+      "CoolProp_x86", EntryPoint = "set_reference_stateD",
       CharSet = CharSet.Ansi)]
     internal static extern int CoolPropDLLfunc_x86(
       string Ref,
@@ -16,7 +16,7 @@ namespace coolprop_wrapper.Functions
       double h0,
       double s0);
     [DllImport(
-      "CoolProp.x64.dll", EntryPoint = "set_reference_stateD",
+      "CoolProp_x64", EntryPoint = "set_reference_stateD",
       CharSet = CharSet.Ansi)]
     internal static extern int CoolPropDLLfunc_x64(
       string Ref,

--- a/wrappers/SMath/coolprop_wrapper/Functions/CoolProp_set_reference_stateS.cs
+++ b/wrappers/SMath/coolprop_wrapper/Functions/CoolProp_set_reference_stateS.cs
@@ -7,13 +7,13 @@ namespace coolprop_wrapper.Functions
   {
     // int set_reference_stateS(const char *Ref, const char *reference_state);
     [DllImport(
-      "CoolProp.x86.dll", EntryPoint = "set_reference_stateS",
+      "CoolProp_x86", EntryPoint = "set_reference_stateS",
       CharSet = CharSet.Ansi)]
     internal static extern int CoolPropDLLfunc_x86(
       string Ref,
       string reference_state);
     [DllImport(
-      "CoolProp.x64.dll", EntryPoint = "set_reference_stateS",
+      "CoolProp_x64", EntryPoint = "set_reference_stateS",
       CharSet = CharSet.Ansi)]
     internal static extern int CoolPropDLLfunc_x64(
       string Ref,

--- a/wrappers/SMath/coolprop_wrapper/build_zip.bat.template
+++ b/wrappers/SMath/coolprop_wrapper/build_zip.bat.template
@@ -7,8 +7,8 @@ rmdir %VERSION% /s /q
 REM Add directory if needed
 mkdir %VERSION%
 
-xcopy bin\Release\CoolProp.x64.dll %VERSION%
-xcopy bin\Release\CoolProp.x86.dll %VERSION%
+xcopy bin\Release\CoolProp_x64.dll %VERSION%
+xcopy bin\Release\CoolProp_x86.dll %VERSION%
 xcopy bin\Release\CoolPropWrapper.dll %VERSION%\
 
 7z a coolprop_wrapper.7z %VERSION% ..\config.ini install.bat


### PR DESCRIPTION
This is required in order to remove ".dll" extension from the library
name in .NET DllImport. And that, in turn, is intended to enable
cross-platform use of SMath wrapper on other OSes, like Linux (that is
supported by both CoolProp and SMath).
As explained at
https://www.collaboraoffice.com/collabora-online-editor-api-reference/,
it's recommended to omit the library extension to allow mono to find
native libraries.
